### PR TITLE
Added IsWindows/AnonymousAuthenticationOverrideAllowed

### DIFF
--- a/src/Rules/IISPSpec.ps1
+++ b/src/Rules/IISPSpec.ps1
@@ -22,3 +22,19 @@ function IsWindowsOptionalFeatureInstalled($feature) {
         Result = (Get-WindowsOptionalFeature -Online -FeatureName $feature).State -eq "Enabled"
     }
 }
+
+function IsWindowsAuthenticationOverrideAllowed($sitePath) {
+	@{
+		Name = $MyInvocation.MyCommand;
+		Info = $sitePath
+		Result = (Get-WebConfiguration -PsPath $sitePath -Filter /system.webServer/security/authentication/windowsAuthentication -MetaData).Metadata.effectiveOverrideMode -eq "Allow"
+	}
+}
+
+function IsAnonymousAuthenticationOverrideAllowed($sitePath) {
+	@{
+		Name = $MyInvocation.MyCommand;
+		Info = $sitePath
+		Result = (Get-WebConfiguration -PsPath $sitePath -Filter /system.webServer/security/authentication/anonymousAuthentication -MetaData).Metadata.effectiveOverrideMode -eq "Allow"
+	}
+}

--- a/test/ExampleSpec.ps1
+++ b/test/ExampleSpec.ps1
@@ -14,5 +14,7 @@ addSpec(IsAnonymousAuthenticationEnabled "IIS:/Sites/Default Web Site")
 addSpec(IsWindowsAuthenticationEnabled "IIS:/Sites/Default Web Site")
 addSpec(IsWindowsOptionalFeatureInstalled "IIS-BasicAuthentication")
 addSpec(DotNetVersionInstalledMinimum 4 5 0)
+addSpec(IsWindowsAuthenticationOverrideAllowed "IIS:\Sites\Default Web Site")
+addSpec(IsAnonymousAuthenticationOverrideAllowed "IIS:\Sites\Default Web Site")
 
 checkSpec


### PR DESCRIPTION
This is for iis configuration, by default the root application node does not allow lower-level sites to do custom setting of windows/anonymous authentication. Just another check on the list!
